### PR TITLE
make system compile with HandleCommandWithReply functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,10 @@ jobs:
     name: Integration
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: 1.16
 
@@ -51,7 +51,7 @@ jobs:
           make test_integration_cover
 
       - name: Store coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: integration.coverprofile
@@ -61,15 +61,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: [unit, integration]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: 1.16
 
       - name: Load coverage
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: coverage
 
@@ -79,13 +79,13 @@ jobs:
           make merge_coverage
 
       - name: Convert coverage
-        uses: jandelgado/gcov2lcov-action@v1.0.5
+        uses: jandelgado/gcov2lcov-action@v1.0.9
         with:
           infile: coverage.out
           outfile: coverage.lcov
 
       - name: Upload coverage
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2.2.3
         with:
           github-token: ${{ secrets.github_token }}
           path-to-lcov: coverage.lcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
     name: Unit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: 1.16
 
@@ -24,7 +24,7 @@ jobs:
           make test_cover
 
       - name: Store coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: unit.coverprofile

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -102,6 +102,9 @@ func (a *TestAggregateRegister) AggregateType() AggregateType {
 func (a *TestAggregateRegister) HandleCommand(ctx context.Context, cmd Command) error {
 	return nil
 }
+func (a *TestAggregateRegister) HandleCommandWithReply(ctx context.Context, cmd Command) (interface{}, error) {
+	return nil, nil
+}
 
 type TestAggregateRegisterEmpty struct {
 	id uuid.UUID
@@ -117,6 +120,9 @@ func (a *TestAggregateRegisterEmpty) AggregateType() AggregateType {
 func (a *TestAggregateRegisterEmpty) HandleCommand(ctx context.Context, cmd Command) error {
 	return nil
 }
+func (a *TestAggregateRegisterEmpty) HandleCommandWithReply(ctx context.Context, cmd Command) (interface{}, error) {
+	return nil, nil
+}
 
 type TestAggregateRegisterTwice struct {
 	id uuid.UUID
@@ -131,4 +137,7 @@ func (a *TestAggregateRegisterTwice) AggregateType() AggregateType {
 }
 func (a *TestAggregateRegisterTwice) HandleCommand(ctx context.Context, cmd Command) error {
 	return nil
+}
+func (a *TestAggregateRegisterTwice) HandleCommandWithReply(ctx context.Context, cmd Command) (interface{}, error) {
+	return nil, nil
 }

--- a/aggregatestore/events/aggregatebase_test.go
+++ b/aggregatestore/events/aggregatebase_test.go
@@ -188,6 +188,9 @@ func NewTestAggregate(id uuid.UUID) *TestAggregate {
 func (a *TestAggregate) HandleCommand(ctx context.Context, cmd eh.Command) error {
 	return nil
 }
+func (a *TestAggregate) HandleCommandWithReply(ctx context.Context, cmd eh.Command) (interface{}, error) {
+	return nil, nil
+}
 
 func (a *TestAggregate) ApplyEvent(ctx context.Context, event eh.Event) error {
 	a.event = event

--- a/aggregatestore/events/aggregatestore_test.go
+++ b/aggregatestore/events/aggregatestore_test.go
@@ -353,6 +353,9 @@ func NewTestAggregateOther(id uuid.UUID) *TestAggregateOther {
 func (a *TestAggregateOther) HandleCommand(ctx context.Context, cmd eh.Command) error {
 	return nil
 }
+func (a *TestAggregateOther) HandleCommandWithReply(ctx context.Context, cmd eh.Command) (interface{}, error) {
+	return nil, nil
+}
 
 func (a *TestAggregateOther) ApplyEvent(ctx context.Context, event eh.Event) error {
 	if a.err != nil {

--- a/aggregatestore/model/aggregatestore_test.go
+++ b/aggregatestore/model/aggregatestore_test.go
@@ -267,6 +267,16 @@ func (a *Aggregate) HandleCommand(ctx context.Context, cmd eh.Command) error {
 
 	return nil
 }
+func (a *Aggregate) HandleCommandWithReply(ctx context.Context, cmd eh.Command) (interface{}, error) {
+	if a.Err != nil {
+		return nil, a.Err
+	}
+
+	a.Commands = append(a.Commands, cmd)
+	a.Context = ctx
+
+	return nil, nil
+}
 
 // AggregateOther is a mocked eventhorizon.Aggregate, useful in testing.
 type AggregateOther struct {

--- a/commandhandler.go
+++ b/commandhandler.go
@@ -21,6 +21,7 @@ import (
 // CommandHandler is an interface that all handlers of commands should implement.
 type CommandHandler interface {
 	HandleCommand(context.Context, Command) error
+	HandleCommandWithReply(context.Context, Command) (interface{}, error)
 }
 
 // CommandHandlerFunc is a function that can be used as a command handler.
@@ -29,4 +30,10 @@ type CommandHandlerFunc func(context.Context, Command) error
 // HandleCommand implements the HandleCommand method of the CommandHandler.
 func (h CommandHandlerFunc) HandleCommand(ctx context.Context, cmd Command) error {
 	return h(ctx, cmd)
+}
+
+// HandleCommandWithReply implements the HandleCommandWithReply method of the CommandHandler
+// for the CommandHandlerFunc, returning nil as the reply.
+func (h CommandHandlerFunc) HandleCommandWithReply(ctx context.Context, cmd Command) (interface{}, error) {
+	return nil, h(ctx, cmd)
 }

--- a/commandhandler/aggregate/commandhandler.go
+++ b/commandhandler/aggregate/commandhandler.go
@@ -78,3 +78,8 @@ func (h *CommandHandler) HandleCommand(ctx context.Context, cmd eh.Command) erro
 
 	return h.store.Save(ctx, a)
 }
+
+// HandleCommandWithReply implements the HandleCommandWithReply method of the Aggregate interface.
+func (h *CommandHandler) HandleCommandWithReply(ctx context.Context, cmd eh.Command) (interface{}, error) {
+	return nil, h.HandleCommand(ctx, cmd)
+}

--- a/commandhandler/bus/commandhandler.go
+++ b/commandhandler/bus/commandhandler.go
@@ -65,6 +65,12 @@ func (h *CommandHandler) HandleCommand(ctx context.Context, cmd eh.Command) erro
 	return ErrHandlerNotFound
 }
 
+// HandleCommandWithReply implements the HandleCommandWithReply method of the
+// eventhorizon.CommandHandler interface.
+func (h *CommandHandler) HandleCommandWithReply(ctx context.Context, cmd eh.Command) (interface{}, error) {
+	return nil, h.HandleCommand(ctx, cmd)
+}
+
 // SetHandler adds a handler for a specific command.
 func (h *CommandHandler) SetHandler(handler eh.CommandHandler, cmdType eh.CommandType) error {
 	h.handlersMu.Lock()

--- a/examples/guestlist/domains/guestlist/aggregate.go
+++ b/examples/guestlist/domains/guestlist/aggregate.go
@@ -133,6 +133,11 @@ func (a *InvitationAggregate) HandleCommand(ctx context.Context, cmd eh.Command)
 	return fmt.Errorf("couldn't handle command")
 }
 
+// HandleCommandWithReply implements the HandleCommandWithReply method of the Aggregate interface.
+func (a *InvitationAggregate) HandleCommandWithReply(ctx context.Context, cmd eh.Command) (interface{}, error) {
+	return nil, a.HandleCommand(ctx, cmd)
+}
+
 // ApplyEvent implements the ApplyEvent method of the Aggregate interface.
 func (a *InvitationAggregate) ApplyEvent(ctx context.Context, event eh.Event) error {
 	switch event.EventType() {

--- a/examples/todomvc/backend/domains/todo/aggregate.go
+++ b/examples/todomvc/backend/domains/todo/aggregate.go
@@ -150,6 +150,12 @@ func (a *Aggregate) HandleCommand(ctx context.Context, cmd eh.Command) error {
 	return nil
 }
 
+// HandleCommandWithReply implements the HandleCommandWithReply method of the
+// eventhorizon.CommandHandler interface.
+func (a *Aggregate) HandleCommandWithReply(ctx context.Context, cmd eh.Command) (interface{}, error) {
+	return nil, a.HandleCommand(ctx, cmd)
+}
+
 // ApplyEvent implements the ApplyEvent method of the
 // eventhorizon.Aggregate interface.
 func (a *Aggregate) ApplyEvent(ctx context.Context, event eh.Event) error {

--- a/httputils/command.go
+++ b/httputils/command.go
@@ -67,3 +67,66 @@ func CommandHandler(commandHandler eh.CommandHandler, commandType eh.CommandType
 		w.WriteHeader(http.StatusOK)
 	})
 }
+
+// CommandHandlerWithReply is a HTTP handler for eventhorizon.Commands. Commands must be
+// registered with eventhorizon.RegisterCommand(). It expects a POST with a JSON
+// body that will be unmarshaled into the command. It differs from CommandHandler by allowing an arbitrary JSON
+// document to be returned as the HTTP reply.
+func CommandHandlerWithReply(commandHandler eh.CommandHandler, commandType eh.CommandType) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "unsupported method: "+r.Method, http.StatusMethodNotAllowed)
+
+			return
+		}
+
+		cmd, err := eh.CreateCommand(commandType)
+		if err != nil {
+			http.Error(w, "could not create command: "+err.Error(), http.StatusBadRequest)
+
+			return
+		}
+
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "could not read command: "+err.Error(), http.StatusBadRequest)
+
+			return
+		}
+
+		if err := json.Unmarshal(b, &cmd); err != nil {
+			http.Error(w, "could not decode command: "+err.Error(), http.StatusBadRequest)
+
+			return
+		}
+
+		// NOTE: Use a new context when handling, else it will be cancelled with
+		// the HTTP request which will cause projectors etc to fail if they run
+		// async in goroutines past the request.
+		var reply interface{}
+
+		ctx := context.Background()
+		if reply, err = commandHandler.HandleCommandWithReply(ctx, cmd); err != nil {
+			http.Error(w, "could not handle command: "+err.Error(), http.StatusBadRequest)
+
+			return
+		}
+
+		var reply_buf []byte = nil
+
+		if reply != nil {
+			reply_buf, err = json.Marshal(reply)
+			if err != nil {
+				http.Error(w, "could not encode reply: "+err.Error(), http.StatusInternalServerError)
+
+				return
+			}
+		}
+
+		w.WriteHeader(http.StatusOK)
+		if reply_buf != nil {
+			w.Write(reply_buf)
+		}
+
+	})
+}

--- a/middleware/commandhandler/lock/middleware_test.go
+++ b/middleware/commandhandler/lock/middleware_test.go
@@ -66,3 +66,9 @@ func (h *LongCommandHandler) HandleCommand(ctx context.Context, cmd eh.Command) 
 
 	return nil
 }
+
+// HandleCommandWithReply implements the HandleCommandWithReply method of the
+// eventhorizon.CommandHandler interface.
+func (h *LongCommandHandler) HandleCommandWithReply(ctx context.Context, cmd eh.Command) (interface{}, error) {
+	return nil, h.HandleCommand(ctx, cmd)
+}

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -95,6 +95,18 @@ func (a *Aggregate) HandleCommand(ctx context.Context, cmd eh.Command) error {
 	return nil
 }
 
+// HandleCommandWithReply implements the HandleCommandWithReply method of the eventhorizon.Aggregate interface.
+func (a *Aggregate) HandleCommandWithReply(ctx context.Context, cmd eh.Command) (interface{}, error) {
+	if a.Err != nil {
+		return nil, a.Err
+	}
+
+	a.Commands = append(a.Commands, cmd)
+	a.Context = ctx
+
+	return nil, nil
+}
+
 func (a *Aggregate) CreateSnapshot() *eh.Snapshot {
 	return &eh.Snapshot{
 		Timestamp: time.Now(),
@@ -208,6 +220,21 @@ func (h *CommandHandler) HandleCommand(ctx context.Context, cmd eh.Command) erro
 	h.Context = ctx
 
 	return nil
+}
+
+// HandleCommandWithReply implements the HandleCommandWithReply method of the eventhorizon.CommandHandler interface.
+func (h *CommandHandler) HandleCommandWithReply(ctx context.Context, cmd eh.Command) (interface{}, error) {
+	h.Lock()
+	defer h.Unlock()
+
+	if h.Err != nil {
+		return nil, h.Err
+	}
+
+	h.Commands = append(h.Commands, cmd)
+	h.Context = ctx
+
+	return nil, nil
 }
 
 // EventHandler is a mocked eventhorizon.EventHandler, useful in testing.


### PR DESCRIPTION
### Description

Enable sending a data body as the result for  a command. In order to select a command to provide a reply, use the `HandleCommandWithReply` function

### Affected Components

- Command Processor

### Steps to test and verify

1. (TODO)
